### PR TITLE
autofix for disallow-const-outside-module-scope

### DIFF
--- a/lib/rules/disallow-const-outside-module-scope.js
+++ b/lib/rules/disallow-const-outside-module-scope.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var cst = require('cst');
 
 module.exports = function() { };
 
@@ -35,5 +36,11 @@ module.exports.prototype = {
         }
       }
     });
+  },
+
+  _fix: function(_, error) {
+    var element = error.element.firstChild;
+    var token = new cst.Token(element.type, element.getSourceCode().replace('const', 'let'));
+    element.parentElement.replaceChild(token, element);
   }
 };


### PR DESCRIPTION
## Changes proposed in this pull request

This PR allows devs to use `$ jscs --fix` on their codebase to fix the rule `disallow-const-outside-module-scope`.

If you think this can be a nice addition to `ember-suave`, I'll update with tests and documentation.